### PR TITLE
fix outdated version arguments

### DIFF
--- a/ch02.ipynb
+++ b/ch02.ipynb
@@ -630,8 +630,8 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "mean_ratings = data.pivot_table('rating', rows='title',\n",
-      "                                cols='gender', aggfunc='mean')\n",
+      "mean_ratings = data.pivot_table('rating', index='title',\n",
+      "                                columns='gender', aggfunc='mean')\n",
       "mean_ratings[:5]"
      ],
      "language": "python",


### PR DESCRIPTION
In put 116:
older ==> mean_ratings = data.pivot_table('rating', rows='title', cols='gender', aggfunc='mean')
new ==>mean_ratings = data.pivot_table('rating', index='title', columns='gender', aggfunc='mean')